### PR TITLE
feat: complete signaling server with peers tracking and cleanup

### DIFF
--- a/server.js
+++ b/server.js
@@ -3,14 +3,34 @@ const app = express();
 const http = require("http").createServer(app);
 const io = require("socket.io")(http, { cors: { origin: "*" } });
 
+// Track the 2 connected users (new part)
+let peers = [];
+
+// Checks for new peer and gives them unique id
 io.on("connection", (socket) => {
+  peers.push(socket.id);
   console.log("User connected:", socket.id);
 
+  // Starter/Trigger (Tell Peer A that Peer B has arrived) (new part)
+  if (peers.length === 2) {
+    io.emit("ready");
+    // both peers now know to start WebRTC
+  }
+
+  // Relay/Forwarder (Pass messages between peers)
   socket.on("offer", (data) => socket.broadcast.emit("offer", data));
   socket.on("answer", (data) => socket.broadcast.emit("answer", data));
   socket.on("ice-candidate", (data) =>
     socket.broadcast.emit("ice-candidate", data),
   );
+
+  // Cleanup (Remove peer when they leave) (new part)
+  socket.on("disconnect", () => {
+    peers = peers.filter((id) => id !== socket.id);
+    console.log("User disconnected:", socket.id);
+    socket.broadcast.emit("peer-left");
+    // tell the other person
+  });
 });
 
 http.listen(3000, () => console.log("Signaling server running on port 3000"));


### PR DESCRIPTION
## What I built (This part is now done)
- Added WebRTC signaling server using Express + Socket.io
- Tracks exactly 2 peers using peers[] array
- Fires "ready" event when both peers connect
- Relays offer, answer, ice-candidate between peers
- Cleans up and notifies when a peer disconnects 

## How to test
- Run: node server.js
- Open app in two browser tabs
- Check console for "User connected" logs