### PR TITLE
fix: improve signaling server with room management

### DIFF
--- a/server.js
+++ b/server.js
@@ -3,34 +3,59 @@ const app = express();
 const http = require("http").createServer(app);
 const io = require("socket.io")(http, { cors: { origin: "*" } });
 
-// Track the 2 connected users (new part)
-let peers = [];
+// Serves index.html and other static files (style.css, script.js)
+// without this, browser cannot load the app
+app.use(express.static(__dirname));
 
 // Checks for new peer and gives them unique id
 io.on("connection", (socket) => {
-  peers.push(socket.id);
   console.log("User connected:", socket.id);
 
-  // Starter/Trigger (Tell Peer A that Peer B has arrived) (new part)
-  if (peers.length === 2) {
-    io.emit("ready");
-    // both peers now know to start WebRTC
-  }
+  // Room Manager - controls who can join which room
+  // Each room has a unique code shared between 2 peers
+  socket.on("join-room", (code) => {
+    const room = io.sockets.adapter.rooms.get(code);
+    const size = room ? room.size : 0;
 
-  // Relay/Forwarder (Pass messages between peers)
-  socket.on("offer", (data) => socket.broadcast.emit("offer", data));
-  socket.on("answer", (data) => socket.broadcast.emit("answer", data));
-  socket.on("ice-candidate", (data) =>
-    socket.broadcast.emit("ice-candidate", data),
+    // Bouncer - blocks 3rd person from joining a full room
+    if (size >= 2) {
+      socket.emit("room-full");
+      console.log(`${socket.id} tried to join full room: ${code}`);
+      return;
+    }
+
+    // Adds peer to the room and remembers which room they are in
+    socket.join(code);
+    socket.currentRoom = code;
+    console.log(`${socket.id} joined room: ${code} (size now: ${size + 1})`);
+
+    // Starter/Trigger - fires when exactly 2 peers are in the room
+    // tells both peers to start the WebRTC handshake
+    if (size === 1) {
+      socket.emit("ready");
+      socket.to(code).emit("peer-joined");
+    }
+  });
+
+  // Relay/Forwarder - passes WebRTC messages between peers in same room
+  // server never reads the data, just passes it through
+  socket.on("offer", ({ code, data }) => socket.to(code).emit("offer", data));
+  socket.on("answer", ({ code, data }) => socket.to(code).emit("answer", data));
+  socket.on("ice-candidate", ({ code, data }) =>
+    socket.to(code).emit("ice-candidate", data),
   );
 
-  // Cleanup (Remove peer when they leave) (new part)
+  // Cleanup - when a peer leaves, notify the other peer in the same room
   socket.on("disconnect", () => {
-    peers = peers.filter((id) => id !== socket.id);
     console.log("User disconnected:", socket.id);
-    socket.broadcast.emit("peer-left");
-    // tell the other person
+    if (socket.currentRoom) {
+      socket.to(socket.currentRoom).emit("peer-left");
+    }
   });
 });
 
-http.listen(3000, () => console.log("Signaling server running on port 3000"));
+// Starts the server on port 3000 (or environment port for deployment)
+const PORT = process.env.PORT || 3000;
+http.listen(PORT, () =>
+  console.log(`Signaling server running on port ${PORT}`),
+);


### PR DESCRIPTION
## Summary
Replaced the global peer array approach with Socket.IO room-based management for proper isolated peer connections.

## Problem with Old Approach
- Used a shared peers[] array to track all connected users globally
- io.emit("ready") broadcasted to *all* connected peers, not just the intended 2
- No room isolation — any peer could interfere with another's session
- No way to handle multiple simultaneous calls

## Benefits
- Multiple video call sessions can run *simultaneously* without interfering
- Cleaner, more scalable architecture using Socket.IO's built-in room system
- Proper peer isolation via room codes